### PR TITLE
Fjernet bruk av google_chrome_version

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -9,7 +9,6 @@ git_config:
 
 docker_version: 17.03.1.ce
 kubectl_version: 1.8.4
-google_chrome_version: 63.0.3239.84
 maven_version: 3.3.9
 node_version: 8.9.1
 jenkins_version: 2.73.2

--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -1,5 +1,5 @@
 #
-# Install Google Chrome
+# Install/update Google Chrome
 #
 - name: Add Google Chome repository
   yum_repository:
@@ -15,10 +15,10 @@
     state: present
     key: https://dl-ssl.google.com/linux/linux_signing_key.pub
 
-- name: "Install google-chrome-{{ google_chrome_version }}"
+- name: Install latest google-chrome-stable
   yum:
-    name: "google-chrome-stable-{{ google_chrome_version }}"
-    state: present
+    name: google-chrome-stable
+    state: latest
 
 #
 # Install/Update git


### PR DESCRIPTION
Ble enige om at det er enklere å bare basere oss på å laste ned siste, enn å drive å oppdatere scriptet for hver ny release.